### PR TITLE
Fix: 狭い画面でURLが突き抜けて右側に余白ができるバグを修正

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -40,6 +40,7 @@ h3 {
 
 .layout-body {
     margin: 20px auto;
+    overflow-wrap: anywhere;
 }
 
 .box-title {


### PR DESCRIPTION
close #1 

.layout-body に overflow-wrap: anywhere; を追加して強制的に改行を入れるようにして対策。